### PR TITLE
Improve `/say` command: clearer descriptions and ephemeral response

### DIFF
--- a/src/commands/admin/say.js
+++ b/src/commands/admin/say.js
@@ -1,15 +1,21 @@
-const { SlashCommandBuilder, PermissionFlagsBits} = require('discord.js');
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
     data: new SlashCommandBuilder()
-    .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
-    .setName('say')
-    .setDescription('send a simple message')
-    .addStringOption(option =>
-    option.setName('message').setDescription('send message').setRequired(true)
-    ),
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
+        .setName('say')
+        .setDescription('Make the bot send a message')
+        .addStringOption(option =>
+            option.setName('message')
+                .setDescription('The message to be sent')
+                .setRequired(true)
+        ),
     
     async execute(interaction) {
-        interaction.reply({ content: interaction.options.getString('message')})
+        const message = interaction.options.getString('message');
+        await interaction.reply({
+            content: message,
+            ephemeral: true // Define como true para evitar spam visível. Pode ser alterado se necessário.
+        });
     },
 };

--- a/src/commands/admin/say.js
+++ b/src/commands/admin/say.js
@@ -15,7 +15,7 @@ module.exports = {
         const message = interaction.options.getString('message');
         await interaction.reply({
             content: message,
-            ephemeral: true // Define como true para evitar spam visível. Pode ser alterado se necessário.
+            ephemeral: true // Define como true para evitar spam visível. Pode ser alterado se necessário...
         });
     },
 };


### PR DESCRIPTION
This PR improves the existing `/say` command by enhancing clarity in both the command and option descriptions, and by using an ephemeral response to prevent channel clutter.

---

### 🔧 **Changes Made:**

* ✏️ Improved the command description to clearly state its purpose.
* 🧾 Enhanced the string option description (`message`) for better context.
* 🕶️ Changed the response to be `ephemeral`, making it visible only to the user who invoked the command (can be adjusted as needed).

---

### 📦 **Updated Code:**

```js
const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');

module.exports = {
    data: new SlashCommandBuilder()
        .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
        .setName('say')
        .setDescription('Make the bot send a message')
        .addStringOption(option =>
            option.setName('message')
                .setDescription('The message to be sent')
                .setRequired(true)
        ),
    
    async execute(interaction) {
        const message = interaction.options.getString('message');
        await interaction.reply({
            content: message,
            ephemeral: true // Prevents channel clutter; visible only to the user
        });
    },
};
```

---

### 🧪 **Testing:**

* ✅ Command executed with valid input.
* ✅ Output returned as expected.
* ✅ Ephemeral response correctly hides the bot message from other users.
* ✅ Permission restrictions (`ManageMessages`) respected.

---

Let me know if you'd prefer the message to be public (`ephemeral: false`) or if you'd like to add a toggle for ephemeral responses.

